### PR TITLE
Page support, default 100 records per page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,15 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -673,6 +682,7 @@ dependencies = [
  "crossterm",
  "ratatui",
  "rusqlite",
+ "sqlformat",
  "sqlparser",
  "strum",
 ]
@@ -701,6 +711,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad8935b44e7c13394a179a438e0cebba0fe08fe01b54f152e29a93b5cf993fd4"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1052,7 +1063,7 @@ dependencies = [
  "crossterm",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.13.0",
  "lru",
  "paste",
  "serde",
@@ -1220,6 +1231,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "sqlformat"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b7922be017ee70900be125523f38bdd644f4f06a1b16e8fa5a8ee8c34bffd4"
+dependencies = [
+ "itertools 0.10.5",
+ "nom",
+ "unicode_categories",
+]
+
+[[package]]
 name = "sqlparser"
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,7 +1320,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1414,7 +1436,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "unicode-segmentation",
  "unicode-width 0.1.14",
 ]
@@ -1430,6 +1452,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ clap = { version = "4.5.27" , features = ["derive"]}
 color-eyre = "0.6.3"
 crossterm = "0.28.1"
 ratatui = { version = "0.29.0", features = ["serde"] }
-rusqlite = "0.33.0"
+rusqlite = { version = "0.33.0", features = ["bundled"] }
 sqlparser = "0.54.0"
+sqlformat = "0.1"
 strum = "0.26.3"

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,13 +10,13 @@ use ratatui::{
 };
 use std::io;
 use string_list::StringList;
-use talbe_view::TableView;
+use table_view::TableView;
 
 pub mod colors;
 pub mod file_menu;
 pub mod help_view;
 pub mod string_list;
-pub mod talbe_view;
+pub mod table_view;
 pub mod utils;
 
 const APP_NAME: &str = " JDbrowser ";

--- a/src/ui/help_view.rs
+++ b/src/ui/help_view.rs
@@ -22,7 +22,7 @@ const NAV_LIST_KEYS: [[&str; 2]; 3] = [
 ];
 
 const TABLE_VIEW_TITLE: &str = " Table View ";
-const TABLE_KEYS: [[&str; 2]; 8] = [
+const TABLE_KEYS: [[&str; 2]; 10] = [
     ["View Schema - Browse Data", "SHIFT + h - l"],
     ["Page Up Half", "u"],
     ["Page Down Half", "d"],
@@ -31,6 +31,8 @@ const TABLE_KEYS: [[&str; 2]; 8] = [
     ["Move Cell Left", "h"],
     ["Move Cell Right", "l"],
     ["Yank Cell to Clipboard", "y"],
+    ["Prev Page", "p"],
+    ["Next Page", "n"],
 ];
 
 const GENERAL_TITLE: &str = " General ";
@@ -48,7 +50,7 @@ pub fn draw_help_window(frame: &mut Frame, lay: Rect) {
     frame.render_widget(background, lay);
 
     let area = center(lay, Constraint::Length(60), Constraint::Length(60));
-    let split_area = Layout::vertical(Constraint::from_lengths([5, 5, 10, 4]))
+    let split_area = Layout::vertical(Constraint::from_lengths([5, 5, 12, 4]))
         .margin(2)
         .split(area);
     let widths = Constraint::from_lengths([40, 14]);


### PR DESCRIPTION
Previously code was loading all records from tables, for big tables it's very slow, hence this change.

It now supports pagination, displays 100 records per page, key n for next page & p for previous.

Also there is an indication string under the preview area for displaying current records of total & current page of total pages

Schema is formatted for better readability.